### PR TITLE
Fix the build issue with kas and env variables 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get clean && apt-get update && apt-get install -y \
     sudo \
     make \
     help2man \
+    man \
     unzip \
     git \
     wget \
@@ -83,6 +84,11 @@ USER $USERNAME
 
 ENV HOME="/home/$USERNAME"
 ENV PATH="$HOME/.local/bin:$PATH"
+
+# Even though Kas exports this variable to BitBake during the build process,
+# sometimes I prefer to source 'pokey/oe-init-build-env' directly when
+# developing recipes. So, to be safe, I still need to export this as an
+# environment variable.
 ENV RPI_ELINUX_ROOT="$HOME/rpi-elinux"
 
 RUN mkdir -p $RPI_ELINUX_ROOT

--- a/yocto/kas-main.yml
+++ b/yocto/kas-main.yml
@@ -5,6 +5,10 @@ distro: poky
 machine: raspberrypi0-wifi
 target: rpi0w-custom-dev
 
+env:
+  RPI_ELINUX_ROOT: "$HOME/rpi-elinux"
+  BB_ENV_PASSTHROUGH_ADDITIONS: "RPI_ELINUX_ROOT"
+
 repos:
   poky:
     url: https://github.com/yoctoproject/poky.git
@@ -28,3 +32,4 @@ local_conf_header:
   meta-custom: |
     ENABLE_UART = "1"
     RPI_USE_U_BOOT = "1"
+    EXTRA_IMAGE_FEATURES = "debug-tweaks"


### PR DESCRIPTION
Kas doesn't pass external environment variables to Bitbake, so if some package relies on them, the build won't compile.